### PR TITLE
PBL-37865: pybluetooth socket should immediately release device in __del__()

### DIFF
--- a/pybluetooth/version.py
+++ b/pybluetooth/version.py
@@ -1,4 +1,4 @@
 __author__ = 'martijnthe'
 
-__version_info__ = (0, 0, 2)
+__version_info__ = (0, 0, 3)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
- The pyusb device was being claimed longer than needed, preventing a BTStack() from grabbing the device after a pyusb_bt_sockets.has_bt_adapter() call.
- Devices matching both the CUSTOM_USB_DEVICE_MATCHER and default bt_adapter_matcher would appear twice in the results of find_all_bt_adapters().
